### PR TITLE
qtpy requirement added to meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,11 @@ requirements:
     - pytables
     - cython
     - pyqt
+    - qtpy
   run:
     - pytables
     - pyqt
+    - qtpy
 
 test:
   commands:


### PR DESCRIPTION
As commented in https://github.com/conda-forge/vitables-feedstock/issues/1 this seems to be needed to install properly the package in some cases.